### PR TITLE
Rustup

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -2,10 +2,7 @@
 
 use libc::{c_uint, c_char, c_int, c_ulong};
 use std::{mem, ptr};
-use std::io;
 use std::fmt;
-use std::str;
-use std::ffi;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::ffi::CString;

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,7 +1,6 @@
 #![allow(unused_must_use)]
 
 use std::cell::RefCell;
-use std::iter;
 use std::vec::Vec;
 use std::rc::Rc;
 use std::collections::HashMap;
@@ -985,7 +984,7 @@ fn cstruct_to_rs(ctx: &mut GenCtx, name: String, ci: CompInfo) -> Vec<P<ast::Ite
     let mut unmangledlist = vec!();
     let mut unmangle_count: HashMap<String, isize> = HashMap::new();
     for v in methodlist {
-        let mut v = v.clone();
+        let v = v.clone();
         match v.ty {
             TFuncPtr(ref sig) => {
                 let name = v.mangled.clone();

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -211,6 +211,7 @@ fn gen_unmangle_func(ctx: &mut GenCtx, v: &VarInfo, counts: &mut HashMap<String,
         node: ast::ItemFn(
             P(fndecl),
             ast::Unsafety::Unsafe,
+            ast::Constness::NotConst,
             abi::C,
             empty_generics(),
             P(block)
@@ -284,6 +285,7 @@ fn gen_unmangle_method(ctx: &mut GenCtx,
         decl: P(fndecl),
         generics: empty_generics(),
         explicit_self: respan(ctx.span, explicit_self),
+        constness: ast::Constness::NotConst,
     };
 
     let block = ast::Block {
@@ -1295,6 +1297,7 @@ fn gen_fullbitfield_method(ctx: &mut GenCtx, bindgen_name: &String,
             decl: P(fndecl),
             generics: empty_generics(),
             explicit_self: respan(ctx.span, ast::SelfStatic),
+            constness: ast::Constness::NotConst,
         }, P(block)
     );
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,6 @@
 #![allow(non_upper_case_globals)]
 
 use std::collections::{HashMap, HashSet};
-use std::collections::hash_map;
 use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;


### PR DESCRIPTION
Added `NotConst` in places where `Constness` info is now required. **Constness should still be considered in those places**, but I think this makes the build work as it did before.

Also removed some "unnecessary mut" and "unused import" warnings.
